### PR TITLE
Making fences work

### DIFF
--- a/verify/asm2boogie/atomics_list.txt
+++ b/verify/asm2boogie/atomics_list.txt
@@ -3,3 +3,4 @@ read_acq
 read_rlx
 write
 cmpxchg
+fence

--- a/verify/asm2boogie/atomics_list.txt
+++ b/verify/asm2boogie/atomics_list.txt
@@ -4,3 +4,4 @@ read_rlx
 write
 cmpxchg
 fence
+fence_acq

--- a/verify/asm2boogie/src/arm/generate.rs
+++ b/verify/asm2boogie/src/arm/generate.rs
@@ -136,6 +136,12 @@ pub fn arm_to_boogie_code(function: &ArmFunction) -> String {
                     ));
                 }
             }
+            ArmInstruction::Dmb(mode) => {
+                code.push_str(&format!(
+                    "    call {} := execute(dmb({}));\n",
+                    DUMMY_REG, mode
+                ));
+            }
             ArmInstruction::Return(_) => {
                 code.push_str("    return;\n");
             }

--- a/verify/asm2boogie/src/arm/mod.rs
+++ b/verify/asm2boogie/src/arm/mod.rs
@@ -2,6 +2,8 @@ mod generate;
 mod parser;
 mod transform;
 
+use std::fmt::Display;
+
 pub use generate::{arm_to_boogie_code, get_used_registers};
 pub use parser::parse_arm_assembly;
 pub use transform::{extract_arm_functions, remove_directives, transform_labels};
@@ -45,6 +47,7 @@ pub enum Operand {
     Label(String),
     ShiftedRegister(Register, String, i64),
     RegisterList(Vec<Register>),
+    FenceMode(FenceType),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -116,10 +119,23 @@ pub struct MemoryAttrs {
     pub release: bool,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum MoveOp {
     Mov,
     Mvn,
+}
+
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum FenceType {
+    SY,
+    LD,
+}
+
+impl Display for FenceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self { Self::SY => "SY()", Self::LD => "LD()" })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -135,6 +151,8 @@ pub enum ArmInstruction {
     MemoryExclusive(MemoryOp, MemoryAttrs, Operand, Operand, Operand),
     Cmp(Operand, Operand),
     Csel(Operand, Operand, Operand, ConditionCode),
+
+    Dmb(FenceType),
 
     Branch(Option<ConditionCode>, Operand),
     BranchLink(Operand),

--- a/verify/asm2boogie/src/lib.rs
+++ b/verify/asm2boogie/src/lib.rs
@@ -125,8 +125,6 @@ pub fn generate_boogie_file(
     output_dir: &str,
     template_dir: &str,
 ) -> Result<(), std::io::Error> {
-
-    println!("attempting: {}",function.name);
     
     let func_type = classify_function(&function.name);
     let templates = get_templates_for_type(func_type);

--- a/verify/asm2boogie/src/lib.rs
+++ b/verify/asm2boogie/src/lib.rs
@@ -125,6 +125,9 @@ pub fn generate_boogie_file(
     output_dir: &str,
     template_dir: &str,
 ) -> Result<(), std::io::Error> {
+
+    println!("attempting: {}",function.name);
+    
     let func_type = classify_function(&function.name);
     let templates = get_templates_for_type(func_type);
 

--- a/verify/asm2boogie/src/lib.rs
+++ b/verify/asm2boogie/src/lib.rs
@@ -32,15 +32,15 @@ pub enum FunctionClass {
     Await,
     AwaitRmw,
     Rmw,
+    Fence,
 }
-
 
 
 static ORDERING: phf::Map<&'static str, (&'static str,&'static str)> = phf_map! {
     "" => ("order_acq_sc","order_rel_sc"),
-    "_rlx" => ("order_acq","order_rlx"),
-    "_acq" => ("order_rlx","order_rel"),
-    "_rel" => ("order_rlx","order_rlx"),
+    "_acq" => ("order_acq","order_rlx"),
+    "_rel" => ("order_rlx","order_rel"),
+    "_rlx" => ("order_rlx","order_rlx"),
 };
 
 
@@ -80,9 +80,11 @@ fn classify_function(name: &str) -> FunctionClass {
         } else {
             FunctionClass::Await
         }
+    } else if name.contains("fence") {
+        FunctionClass::Fence
     } else {
         FunctionClass::Rmw
-    } // @TODO: fences!
+    }
 }
 
 

--- a/verify/asm2boogie/src/main.rs
+++ b/verify/asm2boogie/src/main.rs
@@ -127,7 +127,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             };
             log::info!("Successfully parsed arm assembly");
 
-            let processed_functions = extract_arm_functions(parsed, Some(&function_names), &["64"])
+            let processed_functions = extract_arm_functions(parsed, Some(&function_names), &["64", ""])
                 .into_iter()
                 .map(|f| transform_labels(&f))
                 .map(|f| remove_directives(&f))

--- a/verify/boogie/auxiliary.bpl
+++ b/verify/boogie/auxiliary.bpl
@@ -33,7 +33,8 @@ type StateIndex = int;
 
 
 datatype Effect {
-    read(addr: int, value: int),
+    // read(a,v,vis) == read at a the value v. vis means whether this read is visible to barriers
+    read(addr: int, value: int, visible: bool),
     write(addr: int, value: int)
 }
 var last_load, last_store: StateIndex;

--- a/verify/boogie/auxiliary.bpl
+++ b/verify/boogie/auxiliary.bpl
@@ -169,8 +169,6 @@ axiom order_fence_sc == (lambda fence, entry, exit: StateIndex, ordering: [State
 
 
 
-
-
 function no_writes(from, to, write: StateIndex): bool {
     (write < from || to <= write)
 }
@@ -179,10 +177,11 @@ function no_writes(from, to, write: StateIndex): bool {
 
 type RMWOp = [int, int, int] int;
 
-const cmpset, add_op, set_op, min_op, max_op, ret_old: RMWOp;
+const cmpset, add_op, sub_op, set_op, min_op, max_op, ret_old: RMWOp;
 
 axiom cmpset == (lambda x, y1, y2 : int :: if x == y1 then y2 else x);
 axiom add_op == (lambda x, y, _: int :: x + y);
+axiom sub_op == (lambda x, y, _: int :: x - y);
 axiom set_op == (lambda x, y, _: int :: y);
 axiom min_op == (lambda x, y, _: int :: if x < y then x else y);
 axiom max_op == (lambda x, y, _: int :: if x < y then y else x);

--- a/verify/boogie/auxiliary.bpl
+++ b/verify/boogie/auxiliary.bpl
@@ -151,7 +151,7 @@ axiom order_rel_sc == (lambda store, entry, exit: StateIndex, ordering: [StateIn
 const order_fence_acq: OrderRelation;
 axiom order_fence_acq == (lambda fence, entry, exit: StateIndex, ordering: [StateIndex][Ordering] bool, effects: [StateIndex][Effect] bool ::
         (forall i, j: StateIndex ::
-            (i < entry) && (j >= exit) && (exists e: Effect :: effects[i][e] && e is read) && (exists e: Effect :: effects[j][e])
+            (i < entry) && (j >= exit) && (exists e: Effect :: effects[i][e] && e is read && e->visible) && (exists e: Effect :: effects[j][e])
                 ==> ppo(i, j, ordering, effects))
 );
 

--- a/verify/boogie/templates/read.bpl
+++ b/verify/boogie/templates/read.bpl
@@ -12,7 +12,7 @@ procedure read(ret : RMWOp, load_order: OrderRelation)
     ensures {:msg "load order"}
         load_order[last_load, old(step), step, ordering, effects];
     ensures {:msg "correct output"}
-        (exists v : int :: effects[last_load][read(old(#address),v)] &&
+        (exists v : int :: effects[last_load][read(old(#address),v, true)] &&
                 #output == ret[v, old(#input1), old(#input2)]);
 
 {

--- a/verify/boogie/templates/read_only.bpl
+++ b/verify/boogie/templates/read_only.bpl
@@ -4,7 +4,7 @@ procedure read_only()
     modifies step, effects, ordering, atomic, last_load, last_store, #state, #registers;
     ensures no_writes(old(step), step, last_store);
     ensures {:msg "produced read effects are correct"}
-        old(step) <= last_load && last_load < step ==> effects[last_load][read(old(#address), #output)];
+        old(step) <= last_load && last_load < step ==> effects[last_load][read(old(#address), #output, true)];
 {
     #implementation
 }

--- a/verify/boogie/templates/rmw.bpl
+++ b/verify/boogie/templates/rmw.bpl
@@ -10,7 +10,7 @@ procedure rmw (op: RMWOp)
     ensures {:msg "if no write happened, the value from memory is already the result of operation"} (
         var address, input1, input2 := old(#address), old(#input1), old(#input2);
         no_writes(old(step), step, last_store) ==>
-            (exists a,v : int :: effects[last_load][read(a,v)] && v == op[v, input1, input2])
+            (exists a,v : int, vis : bool :: effects[last_load][read(a,v,vis)] && v == op[v, input1, input2])
         );
     ensures {:msg "atomicity"}
         !no_writes(old(step), step, last_store) ==> (
@@ -19,7 +19,7 @@ procedure rmw (op: RMWOp)
     ensures {:msg "store produces write to correct address with correct value"}
         !no_writes(old(step), step, last_store) ==> (
             var address, input1, input2 := old(#address), old(#input1), old(#input2);
-            (exists a,v : int :: effects[last_load][read(a,v)]
+            (exists a,v : int, vis : bool :: effects[last_load][read(a,v,vis)]
                 && effects[last_store][write(address, op[v, input1, input2])])
         );
 {

--- a/verify/boogie/templates/test.bpl
+++ b/verify/boogie/templates/test.bpl
@@ -11,7 +11,7 @@ procedure read(ret : RMWOp, load_order: OrderRelation)
     ensures {:msg "load order"}
         load_order[last_load, old(step), step, ordering, effects];
     ensures {:msg "correct output"} (
-            exists v : int :: effects[last_load][read(old(a0),v)] &&
+            exists v : int :: effects[last_load][read(old(a0),v,true)] &&
                 a0 == ret[v, old(a1), old(a2)]
         );
 {
@@ -39,7 +39,7 @@ procedure rmw (op: RMWOp)
     ensures {:msg "if no write happened, the value from memory is already the result of operation"} (
         var address, input1, input2 := old(a0), old(a1), old(a2);
         no_writes(old(step), step, last_store) ==>
-            (exists a,v : int :: effects[last_load][read(a,v)] && v == op[v, input1, input2])
+            (exists a,v : int, vis : bool :: effects[last_load][read(a,v,vis)] && v == op[v, input1, input2])
     );
     
     ensures {:msg "atomicity"}
@@ -49,7 +49,7 @@ procedure rmw (op: RMWOp)
     ensures {:msg "store produces write to correct address with correct value"}
         !no_writes(old(step), step, last_store) ==> (
             var address, input1, input2 := old(a0), old(a1), old(a2);
-            (exists a,v : int :: effects[last_load][read(a,v)]
+            (exists a,v : int, vis : bool :: effects[last_load][read(a,v,vis)]
                 && effects[last_store][write(address, op[v, input1, input2])])
         );
 {

--- a/verify/boogie_risc/library.bpl
+++ b/verify/boogie_risc/library.bpl
@@ -75,7 +75,7 @@ procedure execute(instr: Instruction) returns (r : int);
         effects == old(effects[
             step := (
                 ConstArray(false)
-                    [read(instr->addr, r) :=
+                    [read(instr->addr, r, true) :=
                         instr is ld
                         || instr is lr
                     ]


### PR DESCRIPTION
This patch makes fences work correctly. It adds:

- parsing of fences on arm
- fence spec template in boogie
- fence function recognition and template instantiation
- fence semantics in boogie for arm

To enable this correctly, we need to introduce visible vs invisible reads for reads that have ordering semantics vs not.

Furthermore, we make the following unrelated adjustments:
- fix bug with incorrect ordering criteria assumptions generated for acq, rel, rlx
- add sub rmw
- refactor step/last_store assumption