### PR TITLE
Support history constants and loop entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,9 @@ dependencies = [
  "env_logger",
  "lazy_static",
  "log",
+ "nohash",
  "nom",
+ "petgraph",
  "phf",
  "regex",
 ]
@@ -144,10 +146,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -198,6 +228,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "nohash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0f889fb66f7acdf83442c35775764b51fed3c606ab9cee51500dbde2cf528ca"
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +247,16 @@ name = "once_cell"
 version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "phf"

--- a/verify/asm2boogie/Cargo.toml
+++ b/verify/asm2boogie/Cargo.toml
@@ -11,3 +11,5 @@ log = "0.4.26"
 regex = "1.11.1"
 lazy_static = "1.5.0"
 phf = { version = "0.11.3", features = ["macros"] }
+petgraph = "0.7.1"
+nohash = "0.2.0"

--- a/verify/asm2boogie/atomics_list.txt
+++ b/verify/asm2boogie/atomics_list.txt
@@ -5,9 +5,17 @@ write
 write_rel
 write_rlx
 cmpxchg
+cmpxchg_acq
+cmpxchg_rel
+cmpxchg_rlx
 xchg
+xchg_acq
+xchg_rel
+xchg_rel
 fence
 fence_acq
+fence_rel
+fence_rlx
 await_eq_add
 await_gt_sub
 inc

--- a/verify/asm2boogie/gen_atomic_list.rb
+++ b/verify/asm2boogie/gen_atomic_list.rb
@@ -1,0 +1,68 @@
+base_raw = %{
+    read
+    read_acq
+    read_rlx
+    write
+    write_rel
+    write_rlx
+    cmpxchg
+    cmpxchg_acq
+    cmpxchg_rel
+    cmpxchg_rlx
+    xchg
+    xchg_acq
+    xchg_rel
+    xchg_rel
+    fence
+    fence_acq
+    fence_rel
+    fence_rlx
+}.split("\n").map { |s| s.strip }.filter { |s| s != "" }
+
+ops = %{
+    cmpxchg
+    add 
+    sub 
+    xchg
+    set 
+    dec 
+    inc 
+    min 
+    max 
+}.split("\n").map { |s| s.strip }.filter { |s| s != "" }
+
+conds = %{
+    eq
+    neq
+    lt
+    le
+    gt
+    ge
+}.split("\n").map { |s| s.strip }.filter { |s| s != "" }
+
+modes = %{
+    _acq
+    _rel
+    _rlx
+}.split("\n").map { |s| s.strip }
+
+base_raw.each { |b| puts b }
+ops.each { |op|
+    modes.each { |mode| 
+        puts "#{op}#{mode}"
+        puts "get_#{op}#{mode}"
+        puts "#{op}_get#{mode}"
+    }
+}
+
+conds.each { |cond|
+    modes.each { |mode| 
+        puts "await_#{cond}#{mode}"
+    }
+
+    ops.each { |op|
+        modes.each { |mode|
+            puts "await_#{cond}_#{op}#{mode}"
+        }
+    }
+}

--- a/verify/asm2boogie/src/arm/generate.rs
+++ b/verify/asm2boogie/src/arm/generate.rs
@@ -16,7 +16,7 @@ pub fn arm_to_boogie_code(function: &ArmFunction) -> String {
                 if backward_branch_targets.contains(name) {
                     code.push_str("    assert last_store < old(step);\n");
                     code.push_str("    assert step >= old(step);\n");
-                    code.push_str("    assert (forall i : int, e : Effect :: old(step) <= i && i < step && effects[i][e] ==> ! (e is write));\n\n");
+                    code.push_str("    assert (forall i : int, e : Effect :: old(step) <= i && i < step && effects[i] == e ==> ! (e is write));\n\n");
                 }
             }
             ArmInstruction::Arithmetic(op, dest, src1, src2_opt) => {

--- a/verify/asm2boogie/src/arm/generate.rs
+++ b/verify/asm2boogie/src/arm/generate.rs
@@ -1,12 +1,37 @@
+use crate::{loop_headers, UnifiedInstruction};
+
 use super::*;
-use std::collections::HashSet;
+use std::{collections::HashSet, fmt::format};
 
 const DUMMY_REG : &str = "dummy";
+
+
+fn basic_translate(function: &ArmFunction) -> Vec<UnifiedInstruction> {
+    function.instructions.iter().map(|instr|
+        match instr {
+            | ArmInstruction::ConditionalBranch(_, _, target) 
+            | ArmInstruction::Branch(_, target) 
+            | ArmInstruction::TestBitBranch(_, _, _, target)
+                => UnifiedInstruction::Branch("".to_string(), operand_to_boogie(target)),
+
+            | ArmInstruction::Label(name)
+                => UnifiedInstruction::Label(name.clone()),
+
+            | _ => UnifiedInstruction::Instr("".to_string(), vec![]),
+        }
+    ).collect()
+}
 
 pub fn arm_to_boogie_code(function: &ArmFunction) -> String {
     let mut code = String::new();
 
-    let backward_branch_targets = backward_branch_targets(function);
+    let unified_code = basic_translate(function);
+    let loop_header_idx = loop_headers(&unified_code);
+    let backward_branch_targets : HashSet<_> = loop_header_idx.iter().copied().map(|i|
+        match &unified_code[i] {
+            UnifiedInstruction::Label(name) => name.clone(),
+            _ => unreachable!()
+        }).collect();
 
     for instr in &function.instructions {
         match instr {
@@ -145,6 +170,10 @@ pub fn arm_to_boogie_code(function: &ArmFunction) -> String {
             ArmInstruction::Return(_) => {
                 code.push_str("    return;\n");
             }
+            ArmInstruction::Csel(dest, op1, op2, ce) => {
+                code.push_str(&format!("    call {} := execute(csel({}, {}, branch({}, flags)));\n",
+                    operand_to_boogie(dest), operand_to_boogie(op1), operand_to_boogie(op2), condition_to_boogie(ce)));
+            }
             _ => {
                 code.push_str(&format!("    // Unhandled instruction: {:?}\n", instr));
             }
@@ -175,42 +204,6 @@ pub fn get_used_registers(function: &ArmFunction) -> String {
     result.join(", ")
 }
 
-fn backward_branch_targets(function: &ArmFunction) -> HashSet<String> {
-    let mut labels = HashSet::new();
-    let mut targets = HashSet::new();
-
-    for instr in &function.instructions {
-        if let ArmInstruction::Label(name) = instr {
-            labels.insert(name.clone());
-        }
-    }
-
-    let mut current_labels = Vec::new();
-    for instr in &function.instructions {
-        match instr {
-            ArmInstruction::Label(name) => {
-                current_labels.push(name.clone());
-            }
-            ArmInstruction::Branch(_, target) => {
-                if let Operand::Label(label_name) = target {
-                    if current_labels.contains(&label_name) {
-                        targets.insert(label_name.clone());
-                    }
-                }
-            }
-            ArmInstruction::ConditionalBranch(_, _, target) => {
-                if let Operand::Label(label_name) = target {
-                    if current_labels.contains(&label_name) {
-                        targets.insert(label_name.clone());
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-
-    targets
-}
 
 fn collect_registers_from_instruction(instr: &ArmInstruction, registers: &mut HashSet<String>) {
     match instr {
@@ -251,6 +244,11 @@ fn collect_registers_from_instruction(instr: &ArmInstruction, registers: &mut Ha
         }
         ArmInstruction::Return(Some(op)) => {
             collect_registers_from_operand(op, registers);
+        }
+        ArmInstruction::Csel(dest, op1, op2, _ce) => {
+            collect_registers_from_operand(dest, registers);
+            collect_registers_from_operand(op1, registers);
+            collect_registers_from_operand(op2, registers);
         }
         _ => {}
     }
@@ -321,7 +319,7 @@ fn operand_to_boogie(operand: &Operand) -> String {
             }
             _ => "unknown_memory_address".to_string(),
         },
-        Operand::Label(label) => format!("\"{}\"", label),
+        Operand::Label(label) => label.clone(),
         _ => "unknown_operand".to_string(),
     }
 }

--- a/verify/asm2boogie/src/lib.rs
+++ b/verify/asm2boogie/src/lib.rs
@@ -72,6 +72,7 @@ static RMW_OP: phf::Map<&'static str, &'static str> = phf_map! {
     "cmpxchg" => "cmpset",
     "add" => "add_op",
     "sub" => "sub_op",
+    "xchg" => "set_op",
     "set" => "set_op",
     "dec" => "dec_op",
     "inc" => "inc_op",
@@ -179,7 +180,6 @@ pub fn generate_boogie_file(
     template_dir: &str,
     type_map: fn(AtomicType) -> Width,
 ) -> Result<(), std::io::Error> {
-    
     let func_type = classify_function(&function.name);
     let templates = get_templates_for_type(func_type);
 
@@ -191,7 +191,6 @@ pub fn generate_boogie_file(
     let atomic_type = WIDTH_RE.captures(&function.name).map(|c| ATOMIC_TYPE[&c[0]]).unwrap_or(AtomicType::VFENCE);
     let type_width = type_map(atomic_type); 
 
-    println!("function {} type {:?} width {:?}", function.name, atomic_type, &type_width);
     let address = "x0";
     let output = match type_width { Width::Thin => "w0", _ => "x0" };
     let input1 = match type_width { Width::Thin => "w1", _ => "x1" };
@@ -263,6 +262,7 @@ pub fn generate_boogie_file(
 
     }
 
+    println!("generated verification templates for function {}", function.name);
     Ok(())
 }
 

--- a/verify/asm2boogie/verify_all.rb
+++ b/verify/asm2boogie/verify_all.rb
@@ -1,0 +1,65 @@
+require 'optparse'
+
+options = {}
+options[:generate] = true;
+options[:which] = "atomics_list_full.txt"
+options[:where] = "out"
+options[:archs] = ["arm-v8","riscv"]
+options[:extract] = true
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: verify_all.rb [options]"
+
+  opts.on("-s", "--specified=PATH/TO/ATOMICS_LIST", "verify only specified functions") do |v|
+    options[:generate] = false
+    options[:which] = v
+  end
+
+  
+  opts.on("-a", "--architectures=ARCH1,...,ARCHn", "only verify specified architectures") do |v|
+    options[:archs] = v.split.map { |s| s.strip }
+  end
+
+  opts.on("-o", "--output=PATH/TO/OUT", "output folder of templates") do |v|
+    options[:where] = v
+  end
+
+  opts.on("-v", "--verify-only", "only do verification") do |v|
+    options[:extract] = false
+  end
+
+  opts.on("-h", "--help", "Prints this help") do
+    puts opts
+    exit
+  end
+end.parse!
+
+
+def verify(out,atomic,template)
+    `boogie ../boogie/auxiliary.bpl ../boogie_armv8/library.bpl  ../boogie/sc-impl/rcsc.bpl #{out}/#{atomic}/#{template}`.strip
+end
+
+
+
+if options[:generate]
+    `ruby gen_atomic_list.rb > #{options[:which]}`
+end
+
+if options[:extract]
+    options[:archs].each { |arch|
+        `cargo run -- --input data/atomic.s --functions #{options[:which]} --templates ../boogie/templates/ --directory #{options[:where]}/#{arch} --arch #{arch}`
+    }
+end
+
+options[:archs].each { |arch|   
+    base_path = File.join(options[:where], arch)
+    Dir::children(base_path).each { |atomic|
+        puts "======================="
+        puts "verifying #{atomic} on #{arch}"
+        Dir::children(File.join(base_path,atomic)).each { |template|
+            puts "#{template}:"
+            puts verify(base_path, atomic, template)
+            puts "\n"
+        }
+    }
+}

--- a/verify/boogie/templates/await.bpl
+++ b/verify/boogie/templates/await.bpl
@@ -1,7 +1,7 @@
 var #registers: int;
 
 procedure await(cond : AwaitOp)
-    modifies step, effects, ordering, atomic, last_load, last_store, #state, #registers;
+    modifies step, atomic, last_load, last_store, #state, #registers;
 
     ensures {:msg "satisfy await condition"}
         cond[#output, old(#input1)];

--- a/verify/boogie/templates/await.bpl
+++ b/verify/boogie/templates/await.bpl
@@ -4,7 +4,7 @@ procedure await(cond : AwaitOp)
     modifies step, atomic, last_load, last_store, #state, #registers;
 
     ensures {:msg "satisfy await condition"}
-        cond[#output, old(#input1)];
+        cond[effects[last_load]->value, old(#input1)];
 {
     #implementation
 }

--- a/verify/boogie/templates/must_store.bpl
+++ b/verify/boogie/templates/must_store.bpl
@@ -6,7 +6,7 @@ procedure must_store()
         old(step) <= last_store && last_store < step
     );
     ensures {:msg "produces write effect"}
-        effects[last_store][write(old(#address), old(#input1))];
+        effects[last_store] == write(old(#address), old(#input1));
 {
     #implementation
 }

--- a/verify/boogie/templates/read.bpl
+++ b/verify/boogie/templates/read.bpl
@@ -12,7 +12,7 @@ procedure read(ret : RMWOp, load_order: OrderRelation)
     ensures {:msg "load order"}
         load_order[last_load, old(step), step, ordering, effects];
     ensures {:msg "correct output"}
-        (exists v : int :: effects[last_load][read(old(#address),v, true)] &&
+        (exists v : int :: effects[last_load] == read(old(#address),v, true) &&
                 #output == ret[v, old(#input1), old(#input2)]);
 
 {

--- a/verify/boogie/templates/read_only.bpl
+++ b/verify/boogie/templates/read_only.bpl
@@ -1,10 +1,10 @@
 var #registers: int;
 
 procedure read_only()
-    modifies step, effects, ordering, atomic, last_load, last_store, #state, #registers;
+    modifies step, atomic, last_load, last_store, #state, #registers;
     ensures no_writes(old(step), step, last_store);
     ensures {:msg "produced read effects are correct"}
-        old(step) <= last_load && last_load < step ==> effects[last_load][read(old(#address), #output, true)];
+        old(step) <= last_load && last_load < step ==> effects[last_load] == read(old(#address), #output, true);
 {
     #implementation
 }

--- a/verify/boogie/templates/rmw.bpl
+++ b/verify/boogie/templates/rmw.bpl
@@ -20,7 +20,7 @@ procedure rmw (op: RMWOp)
         !no_writes(old(step), step, last_store) ==> (
             var address, input1, input2 := old(#address), old(#input1), old(#input2);
             (exists a,v : int, vis : bool :: effects[last_load] == read(a,v,vis)
-                && effects[last_store] == write(address, op[v, input1, input2)])
+                && effects[last_store] == write(address, op[v, input1, input2]))
         );
 {
     #implementation

--- a/verify/boogie/templates/rmw.bpl
+++ b/verify/boogie/templates/rmw.bpl
@@ -10,7 +10,7 @@ procedure rmw (op: RMWOp)
     ensures {:msg "if no write happened, the value from memory is already the result of operation"} (
         var address, input1, input2 := old(#address), old(#input1), old(#input2);
         no_writes(old(step), step, last_store) ==>
-            (exists a,v : int, vis : bool :: effects[last_load][read(a,v,vis)] && v == op[v, input1, input2])
+            (exists a,v : int, vis : bool :: effects[last_load] == read(a,v,vis) && v == op[v, input1, input2])
         );
     ensures {:msg "atomicity"}
         !no_writes(old(step), step, last_store) ==> (
@@ -19,8 +19,8 @@ procedure rmw (op: RMWOp)
     ensures {:msg "store produces write to correct address with correct value"}
         !no_writes(old(step), step, last_store) ==> (
             var address, input1, input2 := old(#address), old(#input1), old(#input2);
-            (exists a,v : int, vis : bool :: effects[last_load][read(a,v,vis)]
-                && effects[last_store][write(address, op[v, input1, input2])])
+            (exists a,v : int, vis : bool :: effects[last_load] == read(a,v,vis)
+                && effects[last_store] == write(address, op[v, input1, input2)])
         );
 {
     #implementation

--- a/verify/boogie/templates/test.bpl
+++ b/verify/boogie/templates/test.bpl
@@ -11,7 +11,7 @@ procedure read(ret : RMWOp, load_order: OrderRelation)
     ensures {:msg "load order"}
         load_order[last_load, old(step), step, ordering, effects];
     ensures {:msg "correct output"} (
-            exists v : int :: effects[last_load][read(old(a0),v,true)] &&
+            exists v : int :: effects[last_load] == read(old(a0),v,true) &&
                 a0 == ret[v, old(a1), old(a2)]
         );
 {
@@ -22,7 +22,7 @@ procedure read(ret : RMWOp, load_order: OrderRelation)
     loop: 
         // two loop invariants, used in every loop
         assert step >= old(step); 
-        assert (forall i : int, e : Effect :: old(step) <= i && i < step && effects[i][e] ==> ! (e is write));
+        assert (forall i : int, e : Effect :: old(step) <= i && i < step && effects[i] == e ==> ! (e is write));
 
         call a0 := execute(lr(false, false, x5));
         call x6 := execute(add(a0, a1));
@@ -39,7 +39,7 @@ procedure rmw (op: RMWOp)
     ensures {:msg "if no write happened, the value from memory is already the result of operation"} (
         var address, input1, input2 := old(a0), old(a1), old(a2);
         no_writes(old(step), step, last_store) ==>
-            (exists a,v : int, vis : bool :: effects[last_load][read(a,v,vis)] && v == op[v, input1, input2])
+            (exists a,v : int, vis : bool :: effects[last_load] == read(a,v,vis) && v == op[v, input1, input2])
     );
     
     ensures {:msg "atomicity"}
@@ -49,8 +49,8 @@ procedure rmw (op: RMWOp)
     ensures {:msg "store produces write to correct address with correct value"}
         !no_writes(old(step), step, last_store) ==> (
             var address, input1, input2 := old(a0), old(a1), old(a2);
-            (exists a,v : int, vis : bool :: effects[last_load][read(a,v,vis)]
-                && effects[last_store][write(address, op[v, input1, input2])])
+            (exists a,v : int, vis : bool :: effects[last_load] == read(a,v,vis)
+                && effects[last_store] == write(address, op[v, input1, input2)])
         );
 {
     // assumption about parameters
@@ -60,7 +60,7 @@ procedure rmw (op: RMWOp)
     loop: 
         // two loop invariants, used in every loop
         assert step >= old(step); 
-        assert (forall i : int, e : Effect :: old(step) <= i && i < step && effects[i][e] ==> ! (e is write));
+        assert (forall i : int, e : Effect :: old(step) <= i && i < step && effects[i] == e ==> ! (e is write));
 
         call a0 := execute(lr(false, false, x5));
         call x6 := execute(add(a0, a1));
@@ -73,7 +73,7 @@ procedure write(store_order: OrderRelation)
     modifies step, effects, ordering, atomic, last_load, last_store, local_monitor, monitor_exclusive, a0, a1, a2, x5, x6;
     ensures {:msg "no other writes"}
         (forall i : StateIndex ::
-            old(step) <= i && i < step && (exists e : Effect :: effects[i][e] && (e is write))
+            old(step) <= i && i < step && (exists e : Effect :: effects[i] == e && (e is write))
                 ==> i == last_store);
     ensures {:msg "store ordering"}
         !no_writes(old(step), step, last_store) ==> (
@@ -88,7 +88,7 @@ procedure write(store_order: OrderRelation)
     loop: 
         // two loop invariants, used in every loop
         assert step >= old(step); 
-        assert (forall i : int, e : Effect :: old(step) <= i && i < step && effects[i][e] ==> ! (e is write));
+        assert (forall i : int, e : Effect :: old(step) <= i && i < step && effects[i] == e ==> ! (e is write));
 
         call a0 := execute(lr(false, false, x5));
         call x6 := execute(add(a0, a1));

--- a/verify/boogie/templates/write.bpl
+++ b/verify/boogie/templates/write.bpl
@@ -7,7 +7,7 @@ procedure write(store_order: OrderRelation)
     modifies step, effects, ordering, atomic, last_load, last_store, #state, #registers;
     ensures {:msg "no other writes"}
         (forall i : StateIndex ::
-            old(step) <= i && i < step && (exists e : Effect :: effects[i][e] && (e is write))
+            old(step) <= i && i < step && (exists e : Effect :: effects[i] == e && (e is write))
                 ==> i == last_store);
     ensures {:msg "store ordering"}
         !no_writes(old(step), step, last_store)

--- a/verify/boogie_armv8/library.bpl
+++ b/verify/boogie_armv8/library.bpl
@@ -212,7 +212,7 @@ procedure execute(instr: Instruction) returns (r : int);
                     old(flags)
                 )
         &&
-        (effects[step] == if instr is ld
+        (effects[old(step)] == if instr is ld
                             || instr is ldx
                             || instr is cas
                             || instr is swp
@@ -240,7 +240,7 @@ procedure execute(instr: Instruction) returns (r : int);
                         else no_effect() 
             )
         &&
-        (ordering[step] == if instr->acq 
+        (ordering[old(step)] == if instr->acq 
                         && (instr is ld 
                             || instr is ldx
                             || instr is cas

--- a/verify/boogie_risc/library.bpl
+++ b/verify/boogie_risc/library.bpl
@@ -133,16 +133,16 @@ function bnez(r: int): bool {
 }
 
 
-function ppo(step1, step2: StateIndex, ordering: [StateIndex][Ordering] bool, effects: [StateIndex][Effect] bool): bool {
+function ppo(step1, step2: StateIndex, ordering: [StateIndex] Ordering, effects: [StateIndex] Effect): bool {
     step1 < step2 && (
         // Barrier-ordered-before
-        ordering[step1][Acquire()] ||
-        ordering[step1][AcquirePC()] ||
-        ordering[step2][Release()] ||
-        (ordering[step1][Release()] && ordering[step2][Acquire()]) ||
+        ordering[step1] == Acquire() ||
+        ordering[step1] == AcquirePC() ||
+        ordering[step2] == Release() ||
+        (ordering[step1] == Release() && ordering[step2] == Acquire()) ||
 
         (exists fenceId: StateIndex, fence: Ordering, e1, e2: Effect :: 
-            fence is Fence && ordering[fenceId][fence] && effects[step1][e1] && effects[step2][e2] &&
+            fence is Fence && ordering[fenceId] == fence && effects[step1] == e1 && effects[step2] == e2 &&
             (step1 < fenceId && fenceId < step2) &&
             ((fence->ra && e1 is read) ||
              (fence->wa && e1 is write)
@@ -154,6 +154,6 @@ function ppo(step1, step2: StateIndex, ordering: [StateIndex][Ordering] bool, ef
     )
 }
 
-function is_sc(order: [Ordering] bool): bool {
-    order[Acquire()] || order[Release()]
+function is_sc(order: Ordering): bool {
+    order is Acquire || order is Release
 }


### PR DESCRIPTION
Loop verification currently suffers from two serious flaws:
- history variables are modified over the loop, forcing boogie to forget everything it knows about them at loop entry
- the detection of loop entry points for invariant placement is incorrect

We turn history variables into history constants that are assumed to have the correct values from the beginning of the execution, which allows boogie to keep any knowledge about them throughout loops.

We also replace the loop entry point heuristic (based on backwards jumps) with a correct detection using strongly connected components to identify loops, and cross-loop jumps.