### PR TITLE
Repairing Code Generation and Boogie Library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "env_logger",
+ "itertools",
  "lazy_static",
  "log",
  "nohash",
@@ -121,6 +122,12 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
@@ -184,6 +191,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "jiff"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "env_logger",
+ "head-tail-iter",
  "itertools",
  "lazy_static",
  "log",
@@ -169,6 +170,12 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "head-tail-iter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd57aecf4800fa23e8501b514d48a31134cc918add657d3f9682c8e3aa62a5"
 
 [[package]]
 name = "heck"

--- a/verify/asm2boogie/Cargo.toml
+++ b/verify/asm2boogie/Cargo.toml
@@ -13,3 +13,4 @@ lazy_static = "1.5.0"
 phf = { version = "0.11.3", features = ["macros"] }
 petgraph = "0.7.1"
 nohash = "0.2.0"
+itertools = "0.14.0"

--- a/verify/asm2boogie/Cargo.toml
+++ b/verify/asm2boogie/Cargo.toml
@@ -14,3 +14,4 @@ phf = { version = "0.11.3", features = ["macros"] }
 petgraph = "0.7.1"
 nohash = "0.2.0"
 itertools = "0.14.0"
+head-tail-iter = "1.0.1"

--- a/verify/asm2boogie/src/arm/mod.rs
+++ b/verify/asm2boogie/src/arm/mod.rs
@@ -353,7 +353,7 @@ pub fn arm_instruction_to_boogie(instr: &ArmInstruction) -> BoogieInstruction {
             let dest_reg = operand_to_boogie(dest);
             let op1_reg = operand_to_boogie(op1);
             let op2_reg = operand_to_boogie(op2);
-            let cond = condition_code_to_boogie(*ce);
+            let cond = condition_to_boogie(&Condition::Code(*ce));
             BoogieInstruction::Instr(
                 "csel".to_string(),
                 dest_reg,

--- a/verify/asm2boogie/src/arm/mod.rs
+++ b/verify/asm2boogie/src/arm/mod.rs
@@ -193,25 +193,6 @@ pub struct ArmFunction {
     pub instructions: Vec<ArmInstruction>,
 }
 
-impl ArmFunction {
-    pub fn parse_and_transform<'a>(
-        content: &'a str,
-        names: Option<&[String]>,
-        valid_prefix: &[&str],
-    ) -> Result<Vec<ArmFunction>, nom::Err<nom::error::Error<&'a str>>> {
-        let (_, parsed) = parse_arm_assembly(content)?;
-        log::info!("Successfully parsed arm assembly");
-
-        let processed_functions = extract_arm_functions(parsed, names, valid_prefix)
-            .into_iter()
-            .map(|f| transform_labels(&f))
-            .map(|f| remove_directives(&f))
-            .collect::<Vec<_>>();
-
-        Ok(processed_functions)
-    }
-}
-
 pub fn riscv_to_boogie(function: ArmFunction) -> BoogieFunction {
     let instructions = function
         .instructions

--- a/verify/asm2boogie/src/arm/parser.rs
+++ b/verify/asm2boogie/src/arm/parser.rs
@@ -276,7 +276,7 @@ fn parse_directive(input: &str) -> IResult<&str, Directive> {
     .parse(input)
 }
 
-fn parse_label_def(input: &str) -> IResult<&str, ArmInstruction> {
+pub fn parse_label_def(input: &str) -> IResult<&str, ArmInstruction> {
     map(terminated(parse_label, char(':')), |label| {
         ArmInstruction::Label(label)
     })

--- a/verify/asm2boogie/src/arm/parser.rs
+++ b/verify/asm2boogie/src/arm/parser.rs
@@ -581,7 +581,7 @@ fn parse_branch_instruction(
             }
             return Ok((
                 "",
-                ArmInstruction::ConditionalBranch(false, operands[0].clone(), operands[1].clone()),
+                ArmInstruction::Branch(Some(Condition::Zero(operands[0].clone())), operands[1].clone())
             ));
         }
 
@@ -594,7 +594,7 @@ fn parse_branch_instruction(
             }
             return Ok((
                 "",
-                ArmInstruction::ConditionalBranch(true, operands[0].clone(), operands[1].clone()),
+                ArmInstruction::Branch(Some(Condition::NotZero(operands[0].clone())), operands[1].clone())
             ));
         }
 
@@ -653,7 +653,7 @@ fn parse_branch_instruction(
         let condition = parse_condition_code(cond_str);
 
         if let Some(cond) = condition {
-            return Ok(("", ArmInstruction::Branch(Some(cond), operands[0].clone())));
+            return Ok(("", ArmInstruction::Branch(Some(Condition::Code(cond)), operands[0].clone())));
         }
     }
 
@@ -994,7 +994,7 @@ mod tests {
         assert_eq!(
             instr,
             ArmInstruction::Branch(
-                Some(ConditionCode::EQ),
+                Some(Condition::Code(ConditionCode::EQ)),
                 Operand::Label(String::from("label2"))
             )
         );

--- a/verify/asm2boogie/src/arm/transform.rs
+++ b/verify/asm2boogie/src/arm/transform.rs
@@ -69,7 +69,6 @@ pub fn transform_labels(function: &ArmFunction) -> ArmFunction {
             }
             ArmInstruction::Branch(_, Operand::Label(name))
             | ArmInstruction::BranchLink(Operand::Label(name))
-            | ArmInstruction::ConditionalBranch(_, _, Operand::Label(name))
             | ArmInstruction::TestBitBranch(_, _, _, Operand::Label(name)) => {
                 label_refs.push(name.clone());
             }
@@ -111,17 +110,6 @@ pub fn transform_labels(function: &ArmFunction) -> ArmFunction {
                 if let Some(new_name) = label_map.get(name) {
                     new_instructions
                         .push(ArmInstruction::BranchLink(Operand::Label(new_name.clone())));
-                } else {
-                    new_instructions.push(instruction.clone());
-                }
-            }
-            ArmInstruction::ConditionalBranch(cond, op, Operand::Label(name)) => {
-                if let Some(new_name) = label_map.get(name) {
-                    new_instructions.push(ArmInstruction::ConditionalBranch(
-                        *cond,
-                        op.clone(),
-                        Operand::Label(new_name.clone()),
-                    ));
                 } else {
                     new_instructions.push(instruction.clone());
                 }

--- a/verify/asm2boogie/src/generate.rs
+++ b/verify/asm2boogie/src/generate.rs
@@ -23,7 +23,7 @@ pub fn boogie_to_string(instructions: &[BoogieInstruction]) -> String {
                 if backward_branch_targets.contains(name) {
                     code.push_str("    assert last_store < old(step);\n");
                     code.push_str("    assert step >= old(step);\n");
-                    code.push_str("    assert (forall i : int, e : Effect :: old(step) <= i && i < step && effects[i] == e ==> ! (e is write));\n\n");
+                    code.push_str("    assert (forall i : int, e : Effect :: old(step) <= i && i < step && effects[i] == e ==> ! (is_write(e)));\n\n");
                 }
             }
             BoogieInstruction::Instr(name, out, ops) => {

--- a/verify/asm2boogie/src/generate.rs
+++ b/verify/asm2boogie/src/generate.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::{BoogieInstruction, Condition, DUMMY_REG, Operand, loop_headers};
+use crate::{BoogieInstruction, loop_headers};
 
 pub fn boogie_to_string(instructions: &[BoogieInstruction]) -> String {
     let mut code = String::new();
@@ -31,25 +31,11 @@ pub fn boogie_to_string(instructions: &[BoogieInstruction]) -> String {
                     "    call {} := execute({}({}));\n",
                     out,
                     name,
-                    operands_to_string(ops)
+                    ops.join(",")
                 ));
             }
-            BoogieInstruction::ArmBranch(cond, op, target) => {
-                let fun = match cond {
-                    Condition::BZ => format!("cbz({})", operand_to_string(op)),
-                    Condition::BNZ => format!("!cbz({})", operand_to_string(op)),
-                    _ => format!("branch({}, flags)", condition_to_string(cond)),
-                };
-                code.push_str(&format!("    if ({}) {{ goto {}; }}\n", fun, &target,));
-            }
-            BoogieInstruction::RiscvBranch(cond, op1, op2, target) => {
-                let cond_name = condition_to_string(cond);
-                let op1_name = operand_to_string(op1);
-                let op2_name = operand_to_string(op2);
-                code.push_str(&format!(
-                    "    if (branch({}, {}, {})) {{ goto {}; }}\n",
-                    cond_name, op1_name, op2_name, target
-                ));
+            BoogieInstruction::Branch(target, condition) => {
+                code.push_str(&format!("    if ({}) {{ goto {}; }}\n", condition, &target,));
             }
             BoogieInstruction::Jump(target) => {
                 code.push_str(&format!("    goto {};\n", target));
@@ -63,84 +49,4 @@ pub fn boogie_to_string(instructions: &[BoogieInstruction]) -> String {
         }
     }
     code
-}
-
-fn operands_to_string(ops: &[Operand]) -> String {
-    ops.iter()
-        .map(|op| operand_to_string(op))
-        .collect::<Vec<String>>()
-        .join(", ")
-}
-
-fn operand_to_string(op: &Operand) -> String {
-    match op {
-        Operand::Immediate(val) => val.to_string(),
-        Operand::Address(reg) => reg.to_string(),
-        Operand::AdressOffset(reg, offset) => format!("{reg} + {offset}"),
-        Operand::Label(name) => name.to_string(),
-        Operand::Register(name) => name.to_string(),
-        Operand::Bool(val) => val.to_string(),
-        Operand::Value(val) => val.to_string(),
-        Operand::Named(name) => name.to_string(),
-        Operand::Cond(cond) => condition_to_string(cond),
-    }
-}
-
-pub fn get_used_registers(instructions: &[BoogieInstruction]) -> String {
-    let mut registers = HashSet::new();
-
-    for instr in instructions {
-        collect_registers_from_instruction(instr, &mut registers);
-    }
-
-    let mut result = registers.into_iter().collect::<Vec<_>>();
-    result.push(DUMMY_REG.to_string());
-    result.push("x0".to_string());
-    result.push("x1".to_string());
-    result.push("x2".to_string());
-    result.push("w0".to_string());
-    result.push("w1".to_string());
-    result.push("w2".to_string());
-    result.sort();
-    result.dedup();
-    result.join(", ")
-}
-
-fn collect_registers_from_instruction(instr: &BoogieInstruction, registers: &mut HashSet<String>) {
-    match instr {
-        BoogieInstruction::Instr(_name, _, ops) => {
-            for op in ops {
-                collect_registers_from_operand(op, registers);
-            }
-        }
-        BoogieInstruction::ArmBranch(_cond, op, _target) => {
-            collect_registers_from_operand(op, registers);
-        }
-        BoogieInstruction::RiscvBranch(_cond, op1, op2, _target) => {
-            collect_registers_from_operand(op1, registers);
-            collect_registers_from_operand(op2, registers);
-        }
-        _ => {}
-    }
-}
-
-fn collect_registers_from_operand(op: &Operand, registers: &mut HashSet<String>) {
-    match op {
-        Operand::Address(name) | Operand::Register(name) | Operand::AdressOffset(name, _) => {
-            registers.insert(name.to_string());
-        }
-        _ => {}
-    }
-}
-
-fn condition_to_string(cond: &Condition) -> String {
-    match cond {
-        Condition::EQ => "EQ()".to_string(),
-        Condition::NE => "NE()".to_string(),
-        Condition::HS => "HS()".to_string(),
-        Condition::LO => "LO()".to_string(),
-        Condition::HI => "HI()".to_string(),
-        Condition::LS => "LS()".to_string(),
-        _ => "unknown_condition".to_string(),
-    }
 }

--- a/verify/asm2boogie/src/lib.rs
+++ b/verify/asm2boogie/src/lib.rs
@@ -1,4 +1,5 @@
 use generate::boogie_to_string;
+use itertools::Itertools;
 use phf::phf_map;
 use std::{
     collections::{HashMap, HashSet},
@@ -357,6 +358,7 @@ pub fn loop_headers(code: &[BoogieInstruction]) -> HashSet<usize> {
         })
         .collect();
 
+
     for (i, instr) in code.iter().enumerate() {
         match &instr {
             BoogieInstruction::Jump(target) => {
@@ -364,7 +366,6 @@ pub fn loop_headers(code: &[BoogieInstruction]) -> HashSet<usize> {
             }
             BoogieInstruction::Branch(target, _)
             => {
-                println!("{}", target);
                 graph.add_edge(i, label_idx[target], ());
                 graph.add_edge(i, i + 1, ());
             }

--- a/verify/asm2boogie/src/lib.rs
+++ b/verify/asm2boogie/src/lib.rs
@@ -271,6 +271,10 @@ pub fn generate_boogie_file(
                 read_ret = op.to_string();
             }
         }
+
+        if func_type == FunctionClass::AwaitRmw {
+            rmw_op = format!("(lambda x, y1, y2: int :: {}[x, y2, y1])", rmw_op);
+        }
     }
 
     let mut await_cond = "".to_string();
@@ -452,6 +456,8 @@ pub fn loop_headers(code: &[BoogieInstruction]) -> HashSet<usize> {
 
     for (i, instr) in code.iter().enumerate() {
         match &instr {
+            BoogieInstruction::Return => {
+            }
             BoogieInstruction::Jump(target) => {
                 graph.add_edge(i, label_idx[target], ());
             }

--- a/verify/asm2boogie/src/lib.rs
+++ b/verify/asm2boogie/src/lib.rs
@@ -1,10 +1,7 @@
 use generate::boogie_to_string;
 use phf::phf_map;
 use std::{
-    collections::{HashMap, HashSet},
-    fs,
-    io::Write,
-    path::Path,
+    collections::{HashMap, HashSet}, fs, hash::BuildHasher, io::Write, path::Path
 };
 
 use lazy_static::lazy_static;
@@ -359,7 +356,87 @@ pub fn generate_debug_file(boogie: &[BoogieFunction], path: &str) -> Result<(), 
     Ok(())
 }
 
-use petgraph::{Directed, graphmap};
+use petgraph::{graphmap::{self, NodeTrait}, prelude::GraphMap, visit::{EdgeRef, GraphBase, IntoEdgeReferences, IntoEdgesDirected, IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers, NodeIndexable}, Directed, EdgeType};
+
+trait RemoveEdge : GraphBase
+{
+    fn remove_edge(&mut self, to_remove: <Self as GraphBase>::EdgeId);
+}
+
+
+impl <N : PartialEq + Copy + NodeTrait, E, Ty : EdgeType, S:BuildHasher> RemoveEdge for GraphMap<N, E, Ty, S> {
+    fn remove_edge(&mut self, to_remove: Self::EdgeId) {
+        self.remove_edge(to_remove.0, to_remove.1);
+    }
+}
+impl <N : PartialEq + Copy + NodeTrait, E, Ty : EdgeType, S:BuildHasher> IdConvertible for GraphMap<N, E, Ty, S> {
+    fn edge_from_ref(ref_value: <&Self as GraphBase>::EdgeId) -> <Self as GraphBase>::EdgeId {
+        ref_value
+    }
+    fn node_from_ref(ref_value: <&Self as GraphBase>::NodeId) -> <Self as GraphBase>::NodeId {
+        ref_value
+    }
+}
+
+
+trait IdConvertible 
+where Self : GraphBase + Sized {
+    fn edge_from_ref(ref_value: <&Self as GraphBase>::EdgeId) -> <Self as GraphBase>::EdgeId;
+    fn node_from_ref(ref_value: <&Self as GraphBase>::NodeId) -> <Self as GraphBase>::NodeId;
+}
+
+fn loop_headers_iter<G : RemoveEdge + IdConvertible>(cfg: &mut G, loop_entries: &mut HashSet<<G as GraphBase>::NodeId>)
+where for <'a> &'a G : IntoNeighborsDirected + IntoEdgesDirected + IntoNodeIdentifiers + IntoNeighbors + NodeIndexable + IntoEdgeReferences,
+ for <'a> <&'a G as GraphBase>::NodeId: Eq + std::hash::Hash + Copy,
+ <G as GraphBase>::NodeId: Eq + std::hash::Hash + Copy,
+ {
+    let scc = petgraph::algo::tarjan_scc(&*cfg);
+
+
+    for component in scc {
+        let set: HashSet<_> = component.iter().copied().collect();
+        for i in set.iter().copied() {
+            let mut in_loop = false;
+            let mut entry = false;
+            for edge in cfg.edges_directed(i, petgraph::Direction::Incoming) {
+                if set.contains(&edge.source()) {
+                    in_loop = true;
+                } else {
+                    entry = true;
+                }
+            }
+            if in_loop && entry {
+                loop_entries.insert(G::node_from_ref(i));
+            }
+        }
+    }
+ }
+
+
+fn loop_headers_rec<G : RemoveEdge + IdConvertible>(cfg: &mut G, loop_entries: &mut HashSet<<G as GraphBase>::NodeId>)
+where for <'a> &'a G : IntoNeighborsDirected + IntoEdgesDirected + IntoNodeIdentifiers + IntoNeighbors + NodeIndexable + IntoEdgeReferences,
+ for <'a> <&'a G as GraphBase>::NodeId: Eq + std::hash::Hash + Copy,
+ <G as GraphBase>::NodeId: Eq + std::hash::Hash + Copy,
+ {
+    loop {
+        loop_headers_iter(cfg, loop_entries);
+    
+        let edges = cfg.edge_references()
+            .filter(|e| loop_entries.contains(&G::node_from_ref(e.target())))
+            .map(|e| G::edge_from_ref(e.id()))
+            .collect::<Vec<_>>();
+        
+        if edges.is_empty() {
+            break;
+        }
+
+        for e in edges {
+            cfg.remove_edge(e);
+        }
+    }
+
+}
+
 pub fn loop_headers(code: &[BoogieInstruction]) -> HashSet<usize> {
     let mut graph =
         graphmap::GraphMap::<_, _, Directed>::with_capacity(code.len() + 1, 2 * code.len() + 1);
@@ -389,27 +466,8 @@ pub fn loop_headers(code: &[BoogieInstruction]) -> HashSet<usize> {
         }
     }
 
-    let scc = petgraph::algo::tarjan_scc(&graph);
-
+    
     let mut loop_entries = HashSet::new();
-
-    for component in scc {
-        let set: HashSet<_> = component.iter().copied().collect();
-        for i in set.iter().copied() {
-            let mut in_loop = false;
-            let mut entry = false;
-            for n in graph.neighbors_directed(i, petgraph::Direction::Incoming) {
-                if set.contains(&n) {
-                    in_loop = true;
-                } else {
-                    entry = true;
-                }
-            }
-            if in_loop && entry {
-                loop_entries.insert(i);
-            }
-        }
-    }
-
+    loop_headers_rec(&mut graph, &mut loop_entries);
     loop_entries
 }

--- a/verify/asm2boogie/src/main.rs
+++ b/verify/asm2boogie/src/main.rs
@@ -6,6 +6,7 @@ use asm2boogie::{
 };
 
 use clap::{Parser, ValueEnum};
+use itertools::Itertools;
 use std::{fs, iter};
 use std::path::Path;
 

--- a/verify/asm2boogie/src/main.rs
+++ b/verify/asm2boogie/src/main.rs
@@ -1,15 +1,66 @@
+use asm2boogie::arm::{self, extract_arm_functions, parse_arm_assembly};
+use asm2boogie::riscv::{self, extract_riscv_functions, parse_riscv_assembly};
+use asm2boogie::{BoogieFunction, Width, DUMMY_REG};
 use asm2boogie::{
-    Arch, ToBoogie, arm::ArmFunction, generate_boogie_file, generate_debug_file,
-    riscv::RiscvFunction, wide_arch_widths,
+    Arch, ToBoogie, generate_boogie_file, generate_debug_file,
 };
 
-use clap::Parser;
-use std::fs;
+use clap::{Parser, ValueEnum};
+use std::{fs, iter};
 use std::path::Path;
 
 enum OutputMode {
     File(String),
     Directory(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, ValueEnum)]
+enum ArchSpecifier {
+    ArmV8,
+    RiscV,
+}
+
+
+impl Arch for ArchSpecifier {
+    fn name(&self) -> String {
+        format!("{:?}", self)
+    }
+
+    fn registers(&self) -> Vec<String> {
+        match self {
+            ArchSpecifier::ArmV8 => 
+                iter::once(DUMMY_REG.to_string())
+                .chain((0..31).flat_map(|i| [format!("x{}", i), format!("w{}", i)])).collect(),
+            ArchSpecifier::RiscV => 
+                iter::once(DUMMY_REG.to_string())
+                .chain((0..6).map(|i| format!("a{}", i)))
+                .chain((0..11).map(|i| format!("s{}", i)))
+                .chain((0..6).map(|i| format!("t{}", i))).collect(),
+        } 
+    }
+
+    fn width(&self) -> asm2boogie::Width {
+        Width::Wide
+    }
+    
+    fn parse_functions(&self, assembly: &str) -> Result<Vec<BoogieFunction>, Box<dyn std::error::Error>> {
+        /* @TODO intermediate step -- Vec<AsmFunction>. AsmFunction -> BoogieFunction. Here AsmFunction is a generic type of just name + string defining code. */
+        match self {
+            ArchSpecifier::ArmV8 => {
+                let (_, parsed_asm) = parse_arm_assembly(assembly).map_err(|err| err.to_string())?;
+                let functions = extract_arm_functions(parsed_asm, None, &["ptr", "32", "64", "sz", "8", ""])
+                    .into_iter().map(|f| arm::transform_labels(&f));
+                Ok(functions.into_iter().map(ToBoogie::to_boogie).collect())
+            }
+            ArchSpecifier::RiscV => {
+                let (_, parsed_asm) = parse_riscv_assembly(assembly).map_err(|err| err.to_string())?;
+                let functions = extract_riscv_functions(parsed_asm, None, &["ptr", "32", "64", "sz", "8", ""])
+                    .into_iter().map(|f| riscv::transform_labels(&f));
+                Ok(functions.into_iter().map(ToBoogie::to_boogie).collect())
+            }
+        }
+    }
+    
 }
 
 #[derive(Parser, Debug)]
@@ -22,7 +73,7 @@ struct Args {
         default_value = "armv8",
         help = "Target architecture (armv8 or riscv)"
     )]
-    arch: Arch,
+    arch: ArchSpecifier,
     #[clap(short = 'i', long, value_name = "FILE", help = "input file")]
     input: String,
     #[clap(short = 'f', long, value_name = "FILE", help = "function names")]
@@ -115,46 +166,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
     log::info!("Successfully read input file '{}'", args.input);
 
-    let width_map = match args.arch {
-        Arch::ArmV8 => wide_arch_widths,
-        Arch::RiscV => wide_arch_widths,
-    };
+    let name_re = regex::Regex::new(function_names.join("|").as_str())?;
 
-    let valid_prefix: &[&str] = match args.arch {
-        Arch::ArmV8 => &["ptr", "32", "64", "sz", "8", ""],
-        Arch::RiscV => &["64"],
-    };
-
-    let boogie_functions = match args.arch {
-        Arch::ArmV8 => match ArmFunction::parse_and_transform(
-            &input_content,
-            Some(&function_names),
-            valid_prefix,
-        ) {
-            Ok(functions) => functions,
-            Err(e) => {
-                log::error!("Error parsing arm assembly: {:?}", e);
-                std::process::exit(1);
-            }
-        }
-        .into_iter()
-        .map(ToBoogie::to_boogie)
-        .collect::<Vec<_>>(),
-        Arch::RiscV => match RiscvFunction::parse_and_transform(
-            &input_content,
-            Some(&function_names),
-            valid_prefix,
-        ) {
-            Ok(functions) => functions,
-            Err(e) => {
-                log::error!("Error parsing riscv assembly: {:?}", e);
-                std::process::exit(1);
-            }
-        }
-        .into_iter()
-        .map(ToBoogie::to_boogie)
-        .collect::<Vec<_>>(),
-    };
+    let boogie_functions : Vec<_> = args.arch.parse_functions(&input_content)?
+        .iter().filter(|func| name_re.is_match(func.name.as_str()))
+        .cloned()
+        .collect();
 
     match output_mode {
         OutputMode::File(file_path) => {
@@ -168,7 +185,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             for function in &boogie_functions {
                 log::info!("Generating Boogie code for function: {}", function.name);
-                generate_boogie_file(function, &dir_path, template_dir, args.arch, width_map)?;
+                generate_boogie_file(function, &dir_path, template_dir, &args.arch)?;
             }
         }
     }

--- a/verify/asm2boogie/src/riscv/mod.rs
+++ b/verify/asm2boogie/src/riscv/mod.rs
@@ -180,22 +180,23 @@ pub struct RiscvFunction {
     pub instructions: Vec<RiscvInstruction>,
 }
 
-pub fn riscv_to_boogie(function: RiscvFunction) -> BoogieFunction {
-    let instructions = function
-        .instructions
-        .iter()
-        .map(|instr| riscv_instruction_to_boogie(instr))
-        .collect();
-
-    BoogieFunction {
-        name: function.name.clone(),
-        instructions,
-    }
-}
 
 impl ToBoogie for RiscvFunction {
     fn to_boogie(self) -> BoogieFunction {
-        riscv_to_boogie(self)
+        let instructions = self
+            .instructions
+            .iter()
+            .map(|instr| riscv_instruction_to_boogie(instr))
+            .collect();
+    
+        BoogieFunction {
+            name: self.name.clone(),
+            instructions,
+            address: "a0".to_string(),
+            input1: "a1".to_string(),
+            input2: "a2".to_string(),
+            output: "a0".to_string(),
+        }
     }
 }
 

--- a/verify/asm2boogie/src/riscv/mod.rs
+++ b/verify/asm2boogie/src/riscv/mod.rs
@@ -180,25 +180,6 @@ pub struct RiscvFunction {
     pub instructions: Vec<RiscvInstruction>,
 }
 
-impl RiscvFunction {
-    pub fn parse_and_transform<'a>(
-        content: &'a str,
-        names: Option<&[String]>,
-        valid_prefix: &[&str],
-    ) -> Result<Vec<RiscvFunction>, nom::Err<nom::error::Error<&'a str>>> {
-        let (_, parsed) = parse_riscv_assembly(content)?;
-        log::info!("Successfully parsed arm assembly");
-
-        let processed_functions = extract_riscv_functions(parsed, names, valid_prefix)
-            .into_iter()
-            .map(|f| transform_labels(&f))
-            .map(|f| remove_directives(&f))
-            .collect::<Vec<_>>();
-
-        Ok(processed_functions)
-    }
-}
-
 pub fn riscv_to_boogie(function: RiscvFunction) -> BoogieFunction {
     let instructions = function
         .instructions
@@ -212,10 +193,8 @@ pub fn riscv_to_boogie(function: RiscvFunction) -> BoogieFunction {
     }
 }
 
-use itertools::Itertools;
 impl ToBoogie for RiscvFunction {
     fn to_boogie(self) -> BoogieFunction {
-        println!("generating boogie for {}\n    {:?}", self.name, self.instructions.iter().map(|s| format!("{:?}", s)).join("\n    "));
         riscv_to_boogie(self)
     }
 }

--- a/verify/asm2boogie/src/riscv/parser.rs
+++ b/verify/asm2boogie/src/riscv/parser.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use nom::{
     IResult, Parser,
     branch::alt,

--- a/verify/asm2boogie/src/riscv/parser.rs
+++ b/verify/asm2boogie/src/riscv/parser.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use nom::{
     IResult, Parser,
     branch::alt,
@@ -668,7 +669,7 @@ fn parse_line(input: &str) -> IResult<&str, Option<RiscvInstruction>> {
 pub fn parse_riscv_assembly(input: &str) -> IResult<&str, Vec<RiscvInstruction>> {
     let (input, _) = multispace0(input)?;
     let (input, options) = many0(parse_line).parse(input)?;
-    let instructions = options.into_iter().flatten().collect();
+    let instructions: Vec<RiscvInstruction> = options.into_iter().flatten().collect();
     Ok((input, instructions))
 }
 

--- a/verify/asm2boogie/src/riscv/transform.rs
+++ b/verify/asm2boogie/src/riscv/transform.rs
@@ -1,8 +1,7 @@
 use super::*;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use head_tail_iter::HeadTailIterator;
-use itertools::Itertools;
 
 pub fn extract_riscv_functions(
     parsed: Vec<RiscvInstruction>,

--- a/verify/asm2boogie/src/riscv/transform.rs
+++ b/verify/asm2boogie/src/riscv/transform.rs
@@ -21,7 +21,6 @@ pub fn extract_riscv_functions(
                     .map_or(false, |c| c.is_alphabetic() || c == '_') =>
             {
                 if let Some((prev_name, prev_instrs)) = current_function {
-                    println!("{} split {}",prev_name, prev_instrs.iter().map(|s| format!("{:?}", s)).join("\n"));
                     functions.push(RiscvFunction {
                         name: prev_name,
                         instructions: prev_instrs,
@@ -105,16 +104,11 @@ pub fn transform_labels(function: &RiscvFunction) -> RiscvFunction {
         .enumerate()
         .map(|(i, (instr, remaining))| {
             let mut fwd_map: HashMap<&str, usize> = HashMap::new();
-            for (idx, label) in remaining.iter()
-                .filter_map( |instr|
-                    match instr {
-                        RiscvInstruction::Label(label) => Some(label),
-                        _ => None,
-                    }
-                ).enumerate() {
-
-                fwd_map.entry(label.as_str()).or_insert(idx+i+1);
-            };
+            for (idx, instr) in remaining.iter().enumerate() {
+                if let RiscvInstruction::Label(label) = instr {
+                    fwd_map.entry(label.as_str()).or_insert(idx+i+1);
+                }
+            }
             
             match instr {
                 RiscvInstruction::Label(name) => {

--- a/verify/asm2boogie/src/riscv/transform.rs
+++ b/verify/asm2boogie/src/riscv/transform.rs
@@ -1,6 +1,8 @@
 use super::*;
 
 use std::collections::{HashMap, HashSet};
+use head_tail_iter::HeadTailIterator;
+use itertools::Itertools;
 
 pub fn extract_riscv_functions(
     parsed: Vec<RiscvInstruction>,
@@ -19,6 +21,7 @@ pub fn extract_riscv_functions(
                     .map_or(false, |c| c.is_alphabetic() || c == '_') =>
             {
                 if let Some((prev_name, prev_instrs)) = current_function {
+                    println!("{} split {}",prev_name, prev_instrs.iter().map(|s| format!("{:?}", s)).join("\n"));
                     functions.push(RiscvFunction {
                         name: prev_name,
                         instructions: prev_instrs,
@@ -33,6 +36,7 @@ pub fn extract_riscv_functions(
             }
         }
     }
+
 
     if let Some((name, instrs)) = current_function {
         functions.push(RiscvFunction {
@@ -77,141 +81,58 @@ pub fn remove_directives(function: &RiscvFunction) -> RiscvFunction {
     }
 }
 
+macro_rules! to_label_name {
+    ($i:expr) => {
+        format!("L{}", $i)   
+    };
+}
+
+fn get_label_index(fwd_map: &HashMap<&str,usize>, back_map: &HashMap<&str,usize>, label: &String) -> String {
+    let fwd = label.ends_with('f');
+    let bwd = label.ends_with('b');
+    let new_label_idx = if fwd || bwd {
+        let short_label = &label[0..label.len() - 1];
+        (if fwd { &fwd_map } else { &back_map })[short_label]
+    } else {
+        back_map.get(label.as_str()).copied().unwrap_or_else(|| fwd_map[label.as_str()])
+    };
+    to_label_name!(new_label_idx)
+}
+
 pub fn transform_labels(function: &RiscvFunction) -> RiscvFunction {
-    let mut label_defs = Vec::new();
-    let mut label_indices: HashMap<String, Vec<usize>> = HashMap::new();
-
-    for (index, instruction) in function.instructions.iter().enumerate() {
-        if let RiscvInstruction::Label(name) = instruction {
-            if name != &function.name {
-                label_defs.push((index, name.clone()));
-                label_indices
-                    .entry(name.clone())
-                    .or_insert(Vec::new())
-                    .push(index);
-            }
-        }
-    }
-
-    for indices in label_indices.values_mut() {
-        indices.sort();
-    }
-
-    let mut used_positions = HashSet::new();
-    for (i, instruction) in function.instructions.iter().enumerate() {
-        let label = match instruction {
-            RiscvInstruction::Branch { label, .. } | RiscvInstruction::Jump { label, .. } => label,
-            _ => continue,
-        };
-        if label.ends_with('f') || label.ends_with('b') {
-            if let Some(j) = find_label_position(label, i, &label_indices) {
-                used_positions.insert(j);
-            }
-        }
-    }
-
-    let mut used_label_positions: Vec<usize> = label_defs
-        .iter()
-        .filter(|(pos, _)| used_positions.contains(pos))
-        .map(|(pos, _)| *pos)
-        .collect();
-    used_label_positions.sort();
-
-    let mut position_to_new_label = HashMap::new();
-    for (n, &pos) in used_label_positions.iter().enumerate() {
-        position_to_new_label.insert(pos, format!("L{}", n + 1));
-    }
-
-    let mut new_instructions = Vec::new();
-    for (i, instruction) in function.instructions.iter().enumerate() {
-        match instruction {
-            RiscvInstruction::Label(_name) => {
-                if used_positions.contains(&i) {
-                    let new_name = position_to_new_label[&i].clone();
-                    new_instructions.push(RiscvInstruction::Label(new_name));
-                }
-            }
-            RiscvInstruction::Branch {
-                op,
-                rs1,
-                rs2,
-                label,
-            } => {
-                if label.ends_with('f') || label.ends_with('b') {
-                    if let Some(j) = find_label_position(label, i, &label_indices) {
-                        if let Some(new_label) = position_to_new_label.get(&j) {
-                            new_instructions.push(RiscvInstruction::Branch {
-                                op: op.clone(),
-                                rs1: rs1.clone(),
-                                rs2: rs2.clone(),
-                                label: new_label.clone(),
-                            });
-                        } else {
-                            new_instructions.push(RiscvInstruction::Unhandled(format!(
-                                "Unresolved label: {}",
-                                label
-                            )));
-                        }
-                    } else {
-                        new_instructions.push(RiscvInstruction::Unhandled(format!(
-                            "Unresolved label: {}",
-                            label
-                        )));
+    let mut back_map = HashMap::new();
+    let new_instructions = function.instructions.head_tail_pairs()
+        .enumerate()
+        .map(|(i, (instr, remaining))| {
+            let mut fwd_map: HashMap<&str, usize> = HashMap::new();
+            for (idx, label) in remaining.iter()
+                .filter_map( |instr|
+                    match instr {
+                        RiscvInstruction::Label(label) => Some(label),
+                        _ => None,
                     }
-                } else {
-                    new_instructions.push(instruction.clone());
-                }
-            }
-            RiscvInstruction::Jump { rd, label } => {
-                if label.ends_with('f') || label.ends_with('b') {
-                    if let Some(j) = find_label_position(label, i, &label_indices) {
-                        if let Some(new_label) = position_to_new_label.get(&j) {
-                            new_instructions.push(RiscvInstruction::Jump {
-                                rd: rd.clone(),
-                                label: new_label.clone(),
-                            });
-                        } else {
-                            new_instructions.push(RiscvInstruction::Unhandled(format!(
-                                "Unresolved label: {}",
-                                label
-                            )));
-                        }
-                    } else {
-                        new_instructions.push(RiscvInstruction::Unhandled(format!(
-                            "Unresolved label: {}",
-                            label
-                        )));
-                    }
-                } else {
-                    new_instructions.push(instruction.clone());
-                }
-            }
-            _ => new_instructions.push(instruction.clone()),
-        }
-    }
+                ).enumerate() {
 
+                fwd_map.entry(label.as_str()).or_insert(idx+i+1);
+            };
+            
+            match instr {
+                RiscvInstruction::Label(name) => {
+                    back_map.insert(name.as_str(), i);
+                    RiscvInstruction::Label(to_label_name!(i))
+                },
+                RiscvInstruction::Jump { rd, label } => {
+                    RiscvInstruction::Jump { rd: rd.clone(), label: get_label_index(&fwd_map,&back_map, label) }
+                }
+                RiscvInstruction::Branch { op, rs1, rs2, label } => {
+                    RiscvInstruction::Branch { op: op.clone(), rs1: rs1.clone(), rs2: rs2.clone(), label: get_label_index(&fwd_map,&back_map,label) }
+                }
+                _ => instr.clone(),
+            }
+        }).collect();
+    
     RiscvFunction {
         name: function.name.clone(),
         instructions: new_instructions,
-    }
-}
-
-fn find_label_position(
-    label: &str,
-    i: usize,
-    label_indices: &HashMap<String, Vec<usize>>,
-) -> Option<usize> {
-    if label.ends_with('f') {
-        let base = &label[0..label.len() - 1];
-        label_indices
-            .get(base)
-            .and_then(|indices| indices.iter().find(|&&j| j > i).copied())
-    } else if label.ends_with('b') {
-        let base = &label[0..label.len() - 1];
-        label_indices
-            .get(base)
-            .and_then(|indices| indices.iter().rev().find(|&&j| j < i).copied())
-    } else {
-        None
     }
 }

--- a/verify/asm2boogie/verify_all.rb
+++ b/verify/asm2boogie/verify_all.rb
@@ -11,9 +11,16 @@ options[:extract] = true
 OptionParser.new do |opts|
   opts.banner = "Usage: verify_all.rb [options]"
 
-  opts.on("-s", "--specified=PATH/TO/ATOMICS_LIST", "verify only specified functions") do |v|
+  opts.on("-s", "--specified=PATH/TO/ATOMICS_LIST|fun1,...,funk:prop1,...,propn", "verify only specified functions & properties") do |v|
     options[:generate] = false
-    options[:which] = v
+
+    if /\w+(,\w+)*:\w+(,\w+)*/ =~ v
+      funcs, ops = v.split(":").map { |foo| foo.split(",") }
+      options[:limit] = { :functions => funcs, :properties => ops } 
+      puts "only verifying #{funcs} : #{ops}" 
+    else
+      options[:which] = v
+    end
   end
 
   
@@ -25,12 +32,8 @@ OptionParser.new do |opts|
     options[:where] = v
   end
 
-  opts.on("-v", "--verify-only [fun1,...,funk:prop1,...,propn]", "only do verification [of specified functions & properties]") do |v|
+  opts.on("-v", "--verify-only", "only do verification") do |v|
     options[:extract] = false
-    if v
-      funcs, ops = v.split(":").map { |foo| foo.split(",") }
-      options[:limit] = { :functions => funcs, :properties => ops } 
-    end
   end
 
   opts.on("-h", "--help", "Prints this help") do

--- a/verify/asm2boogie/verify_all.rb
+++ b/verify/asm2boogie/verify_all.rb
@@ -1,11 +1,11 @@
 require 'optparse'
 
-archs = { "arm-v8" => ["armv8", "atomics.s"], "risc-v" => ["riscv", "atomic_riscv.s"] }
+Archs = { "arm-v8" => ["armv8", "atomics.s"], "risc-v" => ["risc", "atomic_riscv.s"] }
 options = {}
 options[:generate] = true;
 options[:which] = "atomics_list_full.txt"
 options[:where] = "out"
-options[:archs] = archs.keys
+options[:archs] = Archs.keys
 options[:extract] = true
 
 OptionParser.new do |opts|
@@ -36,8 +36,8 @@ OptionParser.new do |opts|
 end.parse!
 
 
-def verify(arch, out,atomic,template)
-  (library, asm_file) = archs[arch]
+def verify(arch, out, atomic, template)
+  (library, asm_file) = Archs[arch]
   `boogie ../boogie/auxiliary.bpl ../boogie_#{library}/library.bpl  ../boogie/sc-impl/rcsc.bpl #{out}/#{atomic}/#{template}`.strip
 end
 
@@ -51,7 +51,7 @@ end
 
 if options[:extract]
     options[:archs].each { |arch|
-        (library, asm_file) = archs[arch]
+        (library, asm_file) = Archs[arch]
         `cargo run -- --input data/#{asm_file} --functions #{options[:which]} --templates ../boogie/templates/ --directory #{options[:where]}/#{arch} --arch #{arch}`
     }
 end
@@ -63,7 +63,7 @@ options[:archs].each { |arch|
         puts "verifying #{atomic} on #{arch}"
         Dir::children(File.join(base_path,atomic)).each { |template|
             puts "#{template}:"
-            puts verify(base_path, atomic, template)
+            puts verify(arch, base_path, atomic, template)
             puts "\n"
         }
     }

--- a/verify/boogie/auxiliary.bpl
+++ b/verify/boogie/auxiliary.bpl
@@ -201,7 +201,9 @@ function no_writes(from, to, write: StateIndex): bool {
     (write < from || to <= write)
 }
 
-
+function valid_mask(val, mask : int) : bool {
+    val == bit_and(val, mask)
+}
 
 type RMWOp = [int, int, int] int;
 

--- a/verify/boogie/auxiliary.bpl
+++ b/verify/boogie/auxiliary.bpl
@@ -10,7 +10,7 @@
             datatype Ordering
                 different ordering types, like acquire and release ordering or fences
 
-            function is_sc(orders: [Ordering] bool) : bool
+            function is_sc(orders: Ordering) : bool
                 for RCsc
             
             function ppo(i, j: StateIndex, ordering: [StateIndex] Ordering, effects: [StateIndex] Effect): bool 

--- a/verify/boogie/sc-impl/leading-fence.bpl
+++ b/verify/boogie/sc-impl/leading-fence.bpl
@@ -1,1 +1,0 @@
-axiom sc_impl is LeadingFence;

--- a/verify/boogie/sc-impl/rcsc.bpl
+++ b/verify/boogie/sc-impl/rcsc.bpl
@@ -1,1 +1,0 @@
-axiom sc_impl is RCsc;

--- a/verify/boogie/sc-impl/trailing-fence.bpl
+++ b/verify/boogie/sc-impl/trailing-fence.bpl
@@ -1,1 +1,0 @@
-axiom sc_impl is TrailingFence;

--- a/verify/boogie/templates/await.bpl
+++ b/verify/boogie/templates/await.bpl
@@ -1,7 +1,7 @@
 var #registers: int;
 
 procedure await(cond : AwaitOp)
-    modifies step, atomic, last_load, last_store, #state, #registers;
+    modifies step, last_load, last_store, #state, #registers;
 
     ensures {:msg "satisfy await condition"}
         cond[effects[last_load]->value, old(#input1)];

--- a/verify/boogie/templates/await.bpl
+++ b/verify/boogie/templates/await.bpl
@@ -4,7 +4,7 @@ procedure await(cond : AwaitOp)
     modifies step, last_load, last_store, #state, #registers;
 
     ensures {:msg "satisfy await condition"}
-        cond[effects[last_load]->value, old(#input1)];
+        cond[effects[last_load]->read_value, old(#input1)];
 {
     #implementation
 }

--- a/verify/boogie/templates/must_store.bpl
+++ b/verify/boogie/templates/must_store.bpl
@@ -1,7 +1,7 @@
 var #registers: int;
 
 procedure must_store()
-    modifies step, effects, ordering, atomic, last_load, last_store, #state, #registers;
+    modifies step, last_load, last_store, #state, #registers;
     ensures {:msg "store happens within function bounds"} (
         old(step) <= last_store && last_store < step
     );

--- a/verify/boogie/templates/read.bpl
+++ b/verify/boogie/templates/read.bpl
@@ -6,7 +6,7 @@ var #registers: int;
 */
 
 procedure read(ret : RMWOp, load_order: OrderRelation)
-    modifies step, effects, ordering, atomic, local_monitor, monitor_exclusive, flags, event_register, last_load, last_store, #registers;
+    modifies step, last_load, last_store, #state, #registers;
     ensures {:msg "load happens within function bounds"}
         old(step) <= last_load && last_load < step;
     ensures {:msg "load order"}

--- a/verify/boogie/templates/read_only.bpl
+++ b/verify/boogie/templates/read_only.bpl
@@ -1,7 +1,7 @@
 var #registers: int;
 
 procedure read_only()
-    modifies step, atomic, last_load, last_store, #state, #registers;
+    modifies step, last_load, last_store, #state, #registers;
     ensures no_writes(old(step), step, last_store);
     ensures {:msg "produced read effects are correct"}
         old(step) <= last_load && last_load < step ==> effects[last_load] == read(old(#address), #output, true);

--- a/verify/boogie/templates/rmw.bpl
+++ b/verify/boogie/templates/rmw.bpl
@@ -5,7 +5,7 @@ var #registers: int;
 */
 
 procedure rmw (op: RMWOp)
-    modifies step, effects, ordering, atomic, last_load, last_store, #state, #registers;
+    modifies step, last_load, last_store, #state, #registers;
     
     ensures {:msg "if no write happened, the value from memory is already the result of operation"} (
         var address, input1, input2 := old(#address), old(#input1), old(#input2);

--- a/verify/boogie/templates/test.bpl
+++ b/verify/boogie/templates/test.bpl
@@ -22,7 +22,7 @@ procedure read(ret : RMWOp, load_order: OrderRelation)
     loop: 
         // two loop invariants, used in every loop
         assert step >= old(step); 
-        assert (forall i : int, e : Effect :: old(step) <= i && i < step && effects[i] == e ==> ! (e is write));
+        assert (forall i : int, e : Effect :: old(step) <= i && i < step && effects[i] == e ==> ! is_write(e));
 
         call a0 := execute(lr(false, false, x5));
         call x6 := execute(add(a0, a1));
@@ -60,7 +60,7 @@ procedure rmw (op: RMWOp)
     loop: 
         // two loop invariants, used in every loop
         assert step >= old(step); 
-        assert (forall i : int, e : Effect :: old(step) <= i && i < step && effects[i] == e ==> ! (e is write));
+        assert (forall i : int, e : Effect :: old(step) <= i && i < step && effects[i] == e ==> ! (is_write(e)));
 
         call a0 := execute(lr(false, false, x5));
         call x6 := execute(add(a0, a1));
@@ -73,7 +73,7 @@ procedure write(store_order: OrderRelation)
     modifies step, effects, ordering, atomic, last_load, last_store, local_monitor, monitor_exclusive, a0, a1, a2, x5, x6;
     ensures {:msg "no other writes"}
         (forall i : StateIndex ::
-            old(step) <= i && i < step && (exists e : Effect :: effects[i] == e && (e is write))
+            old(step) <= i && i < step && (exists e : Effect :: effects[i] == e && (is_write(e)))
                 ==> i == last_store);
     ensures {:msg "store ordering"}
         !no_writes(old(step), step, last_store) ==> (
@@ -88,7 +88,7 @@ procedure write(store_order: OrderRelation)
     loop: 
         // two loop invariants, used in every loop
         assert step >= old(step); 
-        assert (forall i : int, e : Effect :: old(step) <= i && i < step && effects[i] == e ==> ! (e is write));
+        assert (forall i : int, e : Effect :: old(step) <= i && i < step && effects[i] == e ==> ! (is_write(e)));
 
         call a0 := execute(lr(false, false, x5));
         call x6 := execute(add(a0, a1));

--- a/verify/boogie/templates/write.bpl
+++ b/verify/boogie/templates/write.bpl
@@ -4,7 +4,7 @@ var #registers: int;
     store_order - ordering of store
 */
 procedure write(store_order: OrderRelation)
-    modifies step, effects, ordering, atomic, last_load, last_store, #state, #registers;
+    modifies step, last_load, last_store, #state, #registers;
     ensures {:msg "no other writes"}
         (forall i : StateIndex ::
             old(step) <= i && i < step && (exists e : Effect :: effects[i] == e && (e is write))

--- a/verify/boogie/templates/write.bpl
+++ b/verify/boogie/templates/write.bpl
@@ -7,7 +7,7 @@ procedure write(store_order: OrderRelation)
     modifies step, last_load, last_store, #state, #registers;
     ensures {:msg "no other writes"}
         (forall i : StateIndex ::
-            old(step) <= i && i < step && (exists e : Effect :: effects[i] == e && (e is write))
+            old(step) <= i && i < step && (exists e : Effect :: effects[i] == e && (is_write(e)))
                 ==> i == last_store);
     ensures {:msg "store ordering"}
         !no_writes(old(step), step, last_store)

--- a/verify/boogie_risc/library.bpl
+++ b/verify/boogie_risc/library.bpl
@@ -43,6 +43,29 @@ datatype Instruction {
 }
 
 
+function updated_value(instr: Instruction, read_value : int) : int {
+    if instr->atom is AtomicAdd then instr->src + read_value
+    else if instr->atom is AtomicAnd then and[instr->src, read_value]
+    else if instr->atom is AtomicMax then max[instr->src, read_value]
+    else if instr->atom is AtomicMin then min[instr->src, read_value]
+    else if instr->atom is AtomicOr then or[instr->src, read_value]
+    else if instr->atom is AtomicXor then xor[instr->src, read_value]
+    else if instr->atom is AtomicSwap then instr->src
+    else 0
+}
+
+function rmw(instr: Instruction) : bool {
+    instr is atomic
+}
+
+function reads(instr: Instruction) : bool {
+    rmw(instr) || instr is ld || instr is lr
+}
+
+function writes(instr: Instruction) : bool {
+    rmw(instr) || instr is sd
+}
+
 
 procedure execute(instr: Instruction) returns (r : int);
     modifies step, local_monitor, monitor_exclusive, last_store, last_load;
@@ -63,16 +86,14 @@ procedure execute(instr: Instruction) returns (r : int);
             else r)
         &&
         (last_load ==
-                    if instr is ld
-                     || instr is lr
+                    if reads(instr)
                     then
                         old(step)
                     else
                         old(last_load))
         && 
         (last_store == 
-                    if instr is sd
-                     || (instr is sc && sc_success)
+                    if writes(instr) || (instr is sc && sc_success)
                     then
                         old(step)
                     else
@@ -81,33 +102,29 @@ procedure execute(instr: Instruction) returns (r : int);
         (local_monitor == 
                     if instr is lr then
                         exclusive(instr->addr)
-                    else if instr is sc || instr is sd || instr is ld then
+                    else if writes(instr) || reads(instr) || instr is sc then
                         open()
                     else
                         old(local_monitor))
         &&
-        (effects[old(step)] == if 
-                instr is ld
-                || instr is lr
+        (effects[old(step)] == if rmw(instr) || (instr is sc && sc_success)
+            then update(instr->addr, r, true, updated_value(instr, r))
+            else if reads(instr)
             then read(instr->addr, r, true)
-            else if 
-                instr is sd 
-                || (instr is sc && sc_success)
+            else if writes(instr) 
             then write(instr->addr, instr->src)
             else no_effect())
         &&
-        (ordering[old(step)] == 
+        (ordering[old(step)] ==
             if instr->acq && instr->rel
                 && (instr is lr
-                    || (instr is sc && sc_success))
+                    || (instr is sc && sc_success)
+                    || rmw(instr))
             then AcqRel()
-            else if instr->acq
-                && (instr is ld 
-                    || instr is lr)
+            else if instr->acq && reads(instr)
             then Acquire()
-            else if instr->rel
-                && (instr is sd
-                    || (instr is sc && sc_success))
+            else if (instr->rel && writes(instr))
+                    || (instr is sc && sc_success)
             then Release()
             else if instr is fence
             then Fence(instr->ra, instr->wa, instr->rb, instr->wb) 
@@ -119,14 +136,13 @@ procedure execute(instr: Instruction) returns (r : int);
         || monitor_exclusive == old(
             if instr is lr then
                 true
-            else if (instr is sd || instr is sc) then
+            else if writes(instr) || instr is sc then
                 false
             else
                 monitor_exclusive
         ))
         &&
-        (atomic[last_load, old(step)] == 
-            instr is sc && sc_success)
+        (atomic[last_load, old(step)] == (rmw(instr) || (instr is sc && sc_success)))
     );
 
 function bne(r1: int, r2:int): bool {
@@ -156,11 +172,11 @@ function ppo(step1, step2: StateIndex, ordering: [StateIndex] Ordering, effects:
         (exists fenceId: StateIndex, fence: Ordering, e1, e2: Effect :: 
             fence is Fence && ordering[fenceId] == fence && effects[step1] == e1 && effects[step2] == e2 &&
             (step1 < fenceId && fenceId < step2) &&
-            ((fence->ra && e1 is read) ||
-             (fence->wa && e1 is write)
+            ((fence->ra && is_read(e1)) ||
+             (fence->wa && is_write(e1))
             ) && 
-            ((fence->rb && e2 is read) ||
-             (fence->wb && e2 is write)
+            ((fence->rb && is_read(e2)) ||
+             (fence->wb && is_write(e2))
             )
         )
     )

--- a/verify/boogie_risc/library.bpl
+++ b/verify/boogie_risc/library.bpl
@@ -134,25 +134,6 @@ procedure execute(instr: Instruction) returns (r : int);
         ])
     );
 
-datatype ConditionCode {
-    EQ(), 
-    NE(), 
-    LO(),
-    LS(),
-    HI(),
-    HS()
-}
-
-function branch(cond: ConditionCode, a, b: int): bool {(
-    if cond is EQ then a == b
-    else if cond is NE then a != b
-    else if cond is HS then a >= b
-    else if cond is LO then a < b
-    else if cond is HI then a > b
-    else if cond is LS then a <= b
-    else false // Should never be reached
-)}
-
 function bne(r1: int, r2:int): bool {
     r1 != r2
 }
@@ -160,7 +141,6 @@ function bne(r1: int, r2:int): bool {
 function bnez(r: int): bool {
     r != 0
 }
-
 
 function ppo(step1, step2: StateIndex, ordering: [StateIndex] Ordering, effects: [StateIndex] Effect): bool {
     step1 < step2 && (


### PR DESCRIPTION
This patch series solves several issues introduced in recent refactorings, and fixes some deeper issues in the boogie library.
- We remove platform-specific or redundant pieces of the unified code generation
- We simplify and repair the transformation of labels on RISC-V
- We fix an inconsistency in the boogie library  caused by a lacking modifies clause, which hid several other issues. 
- To solve these issues in boogie, we completely refactor the boogie libraries, including adding a new type of effect for atomic read-modify-write operations.
- To solve these issues in the code generation, we make loop header identification recursive which allows treating nested loops, and fix the loop identification for return statements.
- To solve these issues in the assumption generation for 8 and 16 bit atomics, we add assumptions that certain values fit into 8 resp. 16 bits